### PR TITLE
feat(kg-spec): NFL Event Knowledge Graph — spec, plan, research, data model, contracts, quickstart, tasks

### DIFF
--- a/specs/002-vision-the-nfl/contracts/README.md
+++ b/specs/002-vision-the-nfl/contracts/README.md
@@ -1,0 +1,7 @@
+# Contracts (Phase 1)
+
+This directory contains the contract surface for the Event Knowledge Graph.
+
+- `openapi.yaml`: HTTP contracts for listing events, retrieving details, and summaries with citations.
+
+Contract tests will be generated in the /tasks phase based on these definitions.

--- a/specs/002-vision-the-nfl/contracts/openapi.yaml
+++ b/specs/002-vision-the-nfl/contracts/openapi.yaml
@@ -1,0 +1,47 @@
+openapi: 3.0.3
+info:
+  title: T4L NFL Event KG Contracts
+  version: 0.1.0
+  description: Contract surface for event browsing and evidence viewing
+paths:
+  /events:
+    get:
+      summary: List events
+      parameters:
+        - in: query
+          name: team_id
+          schema: { type: string }
+        - in: query
+          name: player_id
+          schema: { type: string }
+        - in: query
+          name: type
+          schema: { type: string }
+        - in: query
+          name: min_confidence
+          schema: { type: integer, minimum: 0, maximum: 100 }
+      responses:
+        '200':
+          description: OK
+  /events/{event_id}:
+    get:
+      summary: Get event details with claims and citations
+      parameters:
+        - in: path
+          name: event_id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: OK
+  /events/{event_id}/summary:
+    get:
+      summary: Get human-readable event summary with citations
+      parameters:
+        - in: path
+          name: event_id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: OK

--- a/specs/002-vision-the-nfl/data-model.md
+++ b/specs/002-vision-the-nfl/data-model.md
@@ -1,0 +1,82 @@
+# Data Model (Phase 1)
+
+This model reflects the spec’s pragmatic Postgres approach and constitution constraints.
+
+## Entities
+
+- events
+  - event_id (pk)
+  - type (transaction|injury|game|discipline|analysis|rumor)
+  - subtype (signing|extension|trade|waiver|IR|questionable|out|preview|recap|...)
+  - phase (preseason|regular|postseason|offseason|unknown)
+  - week (int|null)
+  - status (rumor|reported|confirmed|superseded)
+  - confidence (int 0-100)
+  - first_seen (timestamptz)
+  - last_seen (timestamptz)
+  - signature_hash (text; unique within 5-day window)
+
+- event_entities
+  - event_id (fk→events)
+  - entity_type (team|player|game)
+  - entity_id (text)
+  - role (subject|counterparty|context)
+
+- claims
+  - claim_id (pk)
+  - event_id (fk→events)
+  - kind (contract|injury_status|game_result|...)
+  - value_json (jsonb)
+  - confidence (int 0-100)
+  - status (rumor|reported|confirmed|superseded)
+
+- claim_sources
+  - claim_id (fk→claims)
+  - article_id (fk→articles)
+  - weight (float)
+
+- event_articles
+  - event_id (fk→events)
+  - article_id (fk→articles)
+  - role (primary|secondary|corroboration)
+  - source_tier (A|B|C)
+  - confidence (int 0-100)
+
+- teams (reference; from nfl_data_py)
+  - team_id (slug)
+  - names (jsonb aliases)
+
+- players (reference; from nfl_data_py)
+  - player_id
+  - name
+  - aliases (jsonb)
+  - position
+
+- player_team_history (optional reference)
+  - player_id (fk→players)
+  - team_id (fk→teams)
+  - start_date
+  - end_date
+
+- sources
+  - source_id (pk)
+  - domain
+  - tier (A|B|C)
+  - policy_mode (strict|preview|provider-context)
+
+- articles (existing)
+  - article_id (pk)
+  - url (unique)
+  - title
+  - publisher
+  - published_at
+
+## Indexes (high level)
+- events(type, week, first_seen DESC)
+- event_entities(event_id), event_entities(entity_type, entity_id)
+- claims(event_id), claims using GIN on value_json
+
+## Invariants
+- Event signature hashing stable for 5-day window
+- Idempotent upserts on URL (articles), signature (events), normalized claim keys
+- Every user-facing fact must be backed by at least one citation

--- a/specs/002-vision-the-nfl/plan.md
+++ b/specs/002-vision-the-nfl/plan.md
@@ -1,0 +1,233 @@
+# Implementation Plan: NFL Event Knowledge Graph
+
+**Branch**: `[002-vision-the-nfl]` | **Date**: 2025-09-08 | **Spec**: /Users/tobiaslatta/Projects/github/bigsliktobi/T4L_End2End/specs/002-vision-the-nfl/spec.md
+**Input**: Feature specification from `/specs/002-vision-the-nfl/spec.md`
+
+## Execution Flow (/plan command scope)
+```
+1. Load feature spec from Input path
+   → If not found: ERROR "No feature spec at {path}"
+2. Fill Technical Context (scan for NEEDS CLARIFICATION)
+   → Detect Project Type from context (web=frontend+backend, mobile=app+api)
+   → Set Structure Decision based on project type
+3. Evaluate Constitution Check section below
+   → If violations exist: Document in Complexity Tracking
+   → If no justification possible: ERROR "Simplify approach first"
+   → Update Progress Tracking: Initial Constitution Check
+4. Execute Phase 0 → research.md
+   → If NEEDS CLARIFICATION remain: ERROR "Resolve unknowns"
+5. Execute Phase 1 → contracts, data-model.md, quickstart.md, agent-specific template file (e.g., `CLAUDE.md` for Claude Code, `.github/copilot-instructions.md` for GitHub Copilot, or `GEMINI.md` for Gemini CLI).
+6. Re-evaluate Constitution Check section
+   → If new violations: Refactor design, return to Phase 1
+   → Update Progress Tracking: Post-Design Constitution Check
+7. Plan Phase 2 → Describe task generation approach (DO NOT create tasks.md)
+8. STOP - Ready for /tasks command
+```
+
+**IMPORTANT**: The /plan command STOPS at step 7. Phases 2-4 are executed by other commands:
+- Phase 2: /tasks command creates tasks.md
+- Phase 3-4: Implementation execution (manual or via tools)
+
+## Summary
+Build a live, provenance-aware NFL Event Knowledge Graph on Supabase that transforms existing nfl-rss/sitemap articles into Events, Entities, and Claims with confidence and citations. Plug into the already implemented RSS/sitemap datastream (no new crawling), apply rules first, then small LLMs where it makes sense (classification, edge disambiguation, allowlisted claim extraction, summaries). Ensure idempotent upserts, 5-day signature clustering, and a normative confidence formula with hysteresis. Reference data (Teams/Players) comes from NFL_DATA_PY into dedicated Supabase tables.
+
+## Technical Context
+**Language/Version**: Python 3.13  
+**Primary Dependencies**: Built-in project libs (Supabase client, repositories), Alembic/SQLAlchemy, nfl_data_py, small LLM wrappers (existing services), pydantic, pytest  
+**Storage**: SQLite (local/testing) → Supabase Postgres (production; authoritative)  
+**Testing**: pytest (unit, contract, integration; existing suites under `tests/`)  
+**Target Platform**: Linux/macOS dev; Supabase Postgres as managed DB  
+**Project Type**: Single backend/data pipeline (Option 1 structure)  
+**Performance Goals**: Time-to-event median < 10–20 min; handle ≥1,000 articles/day; low LLM cost via rules-first  
+**Constraints**: No scraping/crawling; metadata-only; cite every fact; rules before LLM  
+**Scale/Scope**: NFL-wide (32 teams); daily feeds; 5-day event clustering window
+
+## Constitution Check
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+**No Scraping or Crawling**:
+- Using only public feeds, metadata, URL context? (no full crawling)
+- Respecting publisher terms?
+
+**Transparent and Auditable Filtering**:
+- Logging all decisions with scores?
+- Preserving sources, dates, model outputs?
+
+**LLM-Assisted Relevance Checks**:
+- Using small LLMs for ambiguous items?
+- Analyzing only headlines/titles/URLs (no long excerpts)?
+
+**Scalable and Cost-Effective**:
+- Handling 1,000+ articles/day?
+- Layering cheap rules before LLM checks?
+
+**Structured Data Foundation**:
+- Transforming to structured information?
+- Enabling clustering and entity tracking?
+
+**Storage Parity & Migrations**:
+- Single migration source applied to SQLite and Supabase?
+- Schema parity verified (indexes, unique URL, FKs)?
+- Local tests run against SQLite and a Supabase test schema?
+
+## Project Structure
+
+### Documentation (this feature)
+```
+specs/[###-feature]/
+├── plan.md              # This file (/plan command output)
+├── research.md          # Phase 0 output (/plan command)
+├── data-model.md        # Phase 1 output (/plan command)
+├── quickstart.md        # Phase 1 output (/plan command)
+├── contracts/           # Phase 1 output (/plan command)
+└── tasks.md             # Phase 2 output (/tasks command - NOT created by /plan)
+```
+
+### Source Code (repository root)
+```
+# Option 1: Single project (DEFAULT)
+src/
+├── models/
+├── services/
+├── cli/
+└── lib/
+
+tests/
+├── contract/
+├── integration/
+└── unit/
+
+# Option 2: Web application (when "frontend" + "backend" detected)
+backend/
+├── src/
+│   ├── models/
+│   ├── services/
+│   └── api/
+└── tests/
+
+frontend/
+├── src/
+│   ├── components/
+│   ├── pages/
+│   └── services/
+└── tests/
+
+# Option 3: Mobile + API (when "iOS/Android" detected)
+api/
+└── [same as backend above]
+
+ios/ or android/
+└── [platform-specific structure]
+```
+
+**Structure Decision**: [DEFAULT to Option 1 unless Technical Context indicates web/mobile app]
+Structure Decision: Option 1 (single project). Existing modules: `src/services/rss_parser.py`, `src/services/sitemap_parser.py`, `src/services/feed_ingester.py`, `src/services/llm_classifier.py`, `src/database/*`.
+
+## Phase 0: Outline & Research
+1. **Extract unknowns from Technical Context** above:
+   - For each NEEDS CLARIFICATION → research task
+   - For each dependency → best practices task
+   - For each integration → patterns task
+
+2. **Generate and dispatch research agents**:
+   ```
+   For each unknown in Technical Context:
+     Task: "Research {unknown} for {feature context}"
+   For each technology choice:
+     Task: "Find best practices for {tech} in {domain}"
+   ```
+
+3. **Consolidate findings** in `research.md` using format:
+   - Decision: [what was chosen]
+   - Rationale: [why chosen]
+   - Alternatives considered: [what else evaluated]
+
+**Output**: research.md with all NEEDS CLARIFICATION resolved (created)
+
+## Phase 1: Design & Contracts
+*Prerequisites: research.md complete*
+
+1. **Extract entities from feature spec** → `data-model.md`:
+   - Entity name, fields, relationships
+   - Validation rules from requirements
+   - State transitions if applicable
+
+2. **Generate API contracts** from functional requirements:
+   - For each user action → endpoint
+   - Use standard REST/GraphQL patterns
+   - Output OpenAPI/GraphQL schema to `/contracts/`
+
+3. **Generate contract tests** from contracts:
+   - One test file per endpoint
+   - Assert request/response schemas
+   - Tests must fail (no implementation yet)
+
+4. **Extract test scenarios** from user stories:
+   - Each story → integration test scenario
+   - Quickstart test = story validation steps
+
+5. **Update agent file incrementally** (O(1) operation):
+   - Run `/scripts/update-agent-context.sh [claude|gemini|copilot]` for your AI assistant
+   - If exists: Add only NEW tech from current plan
+   - Preserve manual additions between markers
+   - Update recent changes (keep last 3)
+   - Keep under 150 lines for token efficiency
+   - Output to repository root
+
+**Output**: data-model.md, /contracts/*, quickstart.md created; contract tests will be produced in /tasks step
+
+## Phase 2: Task Planning Approach
+*This section describes what the /tasks command will do - DO NOT execute during /plan*
+
+**Task Generation Strategy**:
+- Load `/templates/tasks-template.md` as base
+- Generate tasks from Phase 1 design docs (contracts, data model, quickstart)
+- Each contract → contract test task [P]
+- Each entity → model creation task [P] 
+- Each user story → integration test task
+- Implementation tasks to make tests pass
+
+**Ordering Strategy**:
+- TDD order: Tests before implementation 
+- Dependency order: Models before services before UI
+- Mark [P] for parallel execution (independent files)
+
+**Estimated Output**: 25-30 numbered, ordered tasks in tasks.md
+
+**IMPORTANT**: This phase is executed by the /tasks command, NOT by /plan
+
+## Phase 3+: Future Implementation
+*These phases are beyond the scope of the /plan command*
+
+**Phase 3**: Task execution (/tasks command creates tasks.md)  
+**Phase 4**: Implementation (execute tasks.md following constitutional principles)  
+**Phase 5**: Validation (run tests, execute quickstart.md, performance validation)
+
+## Complexity Tracking
+*Fill ONLY if Constitution Check has violations that must be justified*
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |
+
+
+## Progress Tracking
+*This checklist is updated during execution flow*
+
+**Phase Status**:
+- [x] Phase 0: Research complete (/plan command)
+- [x] Phase 1: Design complete (/plan command)
+- [ ] Phase 2: Task planning complete (/plan command - describe approach only)
+- [ ] Phase 3: Tasks generated (/tasks command)
+- [ ] Phase 4: Implementation complete
+- [ ] Phase 5: Validation passed
+
+**Gate Status**:
+- [x] Initial Constitution Check: PASS
+- [x] Post-Design Constitution Check: PASS
+- [x] All NEEDS CLARIFICATION resolved (alerts/RBAC out of scope; time window 5 days; confidence formula defined; NFL_DATA_PY reference policy set)
+- [ ] Complexity deviations documented
+
+---
+*Based on Constitution v2.1.1 - See `/memory/constitution.md`*

--- a/specs/002-vision-the-nfl/quickstart.md
+++ b/specs/002-vision-the-nfl/quickstart.md
@@ -1,0 +1,23 @@
+# Quickstart (Phase 1)
+
+This validates the end-to-end flow using existing RSS/sitemap ingestion.
+
+## Prereqs
+- Supabase credentials configured (as per project README)
+- Migrations applied; reference tables populated from nfl_data_py
+
+## Steps
+1. Start ingestion of RSS/sitemaps (existing command/cron) to populate articles.
+2. Run the article→event pipeline:
+   - Classify relevance (rules → small LLM for edge cases)
+   - Extract type/subtype, entities, temporal hints
+   - Upsert Event with 5-day signature window
+   - Attach Articles; compute confidence; optionally extract structured Claims (allowlisted)
+3. Inspect results:
+   - Query Events by team/player; verify citations and confidence
+   - Check summaries show citations and "unknown" where applicable
+
+## Expected Outcome
+- New or updated Events with citations and computed confidence
+- Deduped clustering for near-duplicate reports
+- Structured Claims for allowlisted sources when present

--- a/specs/002-vision-the-nfl/research.md
+++ b/specs/002-vision-the-nfl/research.md
@@ -1,0 +1,22 @@
+# Phase 0 Research: NFL Event Knowledge Graph
+
+## Decisions
+- Source integration: Use existing rss/sitemap ingestion services; no new crawlers.
+- Entity lexicons: Source Teams/Players from nfl_data_py; store in Supabase reference tables; daily in-season, weekly off-season, on-demand refresh.
+- Event clustering window: 5 days (rolling from first_seen).
+- Confidence: Normative formula with E, Cb, K, O, Rm; hysteresis at 65/85 promote and 55/75 demote.
+- DB: Supabase Postgres is authoritative; SQLite mirrors for local tests.
+- LLM usage: Small models for ambiguity classification, claim extraction (allowlisted), and summaries with mandatory citations.
+
+## Rationale
+- Aligns with constitution (no scraping; metadata-only) and cost goals (rules before LLM).
+- 5-day window captures multi-day storylines while limiting over-merge.
+- nfl_data_py provides stable canonical entities; Supabase keeps centralized source of truth.
+
+## Alternatives Considered
+- Neo4j/graph store first: deferred; start with Postgres tables per spec.
+- Full-page scraping for claims: rejected due to compliance.
+- Longer window (7-10 days): increases accidental merges.
+
+## Open Points Resolved
+- Alerts & RBAC: out of scope for this feature; to be handled in later specs.

--- a/specs/002-vision-the-nfl/spec.md
+++ b/specs/002-vision-the-nfl/spec.md
@@ -1,0 +1,191 @@
+# Feature Specification: NFL Event Knowledge Graph
+
+**Feature Branch**: `[002-vision-the-nfl]`  
+**Created**: 2025-09-08  
+**Status**: Draft  
+**Input**: Vision to build a live, provenance-aware knowledge graph that turns raw NFL news articles into Events, Entities, and Claims with timestamps, confidence, and citations; supports deduped timelines, auditing, summaries with citations, and downstream content generation.
+
+## Execution Flow (main)
+```
+1. Parse user description from Input
+   → If empty: ERROR "No feature description provided"
+2. Extract key concepts from description
+   → Identify: actors, actions, data, constraints
+3. For each unclear aspect:
+   → Mark with [NEEDS CLARIFICATION: specific question]
+4. Fill User Scenarios & Testing section
+   → If no clear user flow: ERROR "Cannot determine user scenarios"
+5. Generate Functional Requirements
+   → Each requirement must be testable
+   → Mark ambiguous requirements
+6. Identify Key Entities (if data involved)
+7. Run Review Checklist
+   → If any [NEEDS CLARIFICATION]: WARN "Spec has uncertainties"
+   → If implementation details found: ERROR "Remove tech details"
+8. Return: SUCCESS (spec ready for planning)
+```
+
+---
+
+## ⚡ Quick Guidelines
+- ✅ Focus on WHAT users need and WHY
+- ❌ Avoid HOW to implement (no tech stack, APIs, code structure)
+- 👥 Written for business stakeholders, not developers
+
+### Section Requirements
+- **Mandatory sections**: Must be completed for every feature
+- **Optional sections**: Include only when relevant to the feature
+- When a section doesn't apply, remove it entirely (don't leave as "N/A")
+
+### For AI Generation
+When creating this spec from a user prompt:
+1. **Mark all ambiguities**: Use [NEEDS CLARIFICATION: specific question] for any assumption you'd need to make
+2. **Don't guess**: If the prompt doesn't specify something (e.g., "login system" without auth method), mark it
+3. **Think like a tester**: Every vague requirement should fail the "testable and unambiguous" checklist item
+4. **Common underspecified areas**:
+   - User types and permissions
+   - Data retention/deletion policies  
+   - Performance targets and scale
+   - Error handling behaviors
+   - Integration requirements
+   - Security/compliance needs
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### Primary User Story
+As a football fan or content editor, I want timely, trustworthy event records (signings, injuries, trades, game recaps) consolidated from multiple sources with clear confidence and citations, so I can understand what happened, who’s involved, and create content that is consistent and auditable.
+
+### Acceptance Scenarios
+1. Given a new reputable article about a player signing, when the system processes the item, then a single Event is present with type "transaction/signing," the involved Team and Player attached, first_seen set, confidence calculated, and at least one citation to the source article.
+2. Given two differently worded articles about the same event within a short window, when both are processed, then they are clustered into the same Event, citations include both, and confidence increases due to corroboration.
+3. Given an allowlisted source that includes clear factual details (e.g., contract years and amount), when processed, then a structured Claim is added to the Event with provenance and a confidence appropriate to source policy.
+4. Given conflicting details from lower-tier sources, when processed, then the system records evidence but keeps Event confidence conservative and marks discrepancy until high-tier corroboration arrives.
+5. Given a later correction or update, when processed, then the Event and/or Claims are updated, last_seen is revised, and the summary reflects the change with updated citations.
+
+### Edge Cases
+- Ambiguous or pun-heavy headlines with missing entities → system defers to low-confidence hints and awaits corroboration.
+- Multiple similar events (e.g., two extensions on the same team the same day) → ensure signature prevents cross-association.
+- Rumor-only items → recorded with low confidence and status "rumor," excluded from high-confidence feeds unless promoted.
+- Corrections that invalidate earlier claims → prior claims marked superseded; summaries update accordingly.
+- Out-of-season or off-calendar events → still captured; temporal context marked as preseason/offseason.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+- **FR-001**: System MUST classify incoming article items as in-scope NFL event news or out-of-scope, using title, URL, and publisher metadata.
+- **FR-002**: For in-scope items, System MUST extract an Event type and subtype (e.g., transaction/signing, injury/out, game/recap).
+- **FR-003**: System MUST identify and normalize referenced Teams and Players to canonical identities.
+- **FR-004**: System MUST capture temporal context when present (phase and/or week) or mark it unknown when not derivable.
+- **FR-005**: System MUST construct an Event signature from type plus key entities and a 5-day time window (120 hours, rolling from first_seen), and use it to attach evidence to an existing Event or create a new one.
+- **FR-006**: System MUST deduplicate near-duplicate reports about the same real-world event and cluster them under a single Event.
+- **FR-007**: System MUST record first_seen when an Event is created and update last_seen as new evidence arrives.
+- **FR-008**: System MUST associate source Articles to Events with role, source tier, and per-article confidence.
+- **FR-009**: System MUST support structured Claims for Events (e.g., contract terms, injury status) when extractable from permitted metadata, including kind, values, confidence, and status.
+- **FR-010**: System MUST record provenance for each Claim, linking to contributing Articles and weighting when applicable.
+- **FR-011**: System MUST compute an Event-level confidence based on source mix, corroboration count, and cross-source consistency, and update it as evidence changes.
+- **FR-012**: System MUST enforce per-domain policy modes (e.g., strict, preview, provider-context) that govern what metadata can be used for claims and summaries.
+- **FR-013**: System MUST behave idempotently by upserting Articles by URL, Events by signature within the defined time window, and Claims by normalized key.
+- **FR-014**: System MUST maintain an audit trail of changes to Events and Claims with timestamps and reasons (e.g., new evidence, correction, merge/split).
+- **FR-015**: System MUST provide controlled operations to merge duplicate Events and to split conflated Events, preserving provenance.
+- **FR-016**: System MUST provide an Event-level human-readable summary: one-line overview plus bullet points, each with citations after every fact.
+- **FR-017**: Users MUST be able to browse and filter Events by team, player, type/subtype, temporal context, and confidence threshold.
+- **FR-018**: Users MUST be able to subscribe to alerts for specific teams, players, or event types and receive notifications for new or updated high-confidence Events.
+- **FR-019**: System MUST report run-level metrics including counts of created/updated Events and Claims, merges/splits, average processing latency, and model usage rate.
+- **FR-020**: System MUST present unknown values explicitly as "unknown" rather than inferring or fabricating data in summaries or claims.
+- **FR-021**: System MUST support event and claim status states (e.g., rumor, reported, confirmed, superseded) with clear promotion rules.
+- **FR-022**: System MUST ensure every fact presented in user-facing summaries has at least one citation.
+- **FR-023**: System MUST support partner-facing health metrics (coverage by team, time-to-event, corroboration rate) accessible for review.
+
+- **FR-024**: System MUST compute the Event confidence score S and assign status per the "Confidence Computation and Status Thresholds" rules below.
+- **FR-025**: System MUST apply hysteresis to avoid oscillation: promote at S ≥ 65 (Reported) and S ≥ 85 (Confirmed); demote at S < 55 and S < 75 respectively, and on explicit retraction by an official source.
+- **FR-026**: System MUST deduplicate evidence by domain for corroboration and cap the number of counted sources so that no single domain overwhelms the score.
+
+- **FR-027**: System MUST source canonical Team and Player lexicons from the NFL_DATA_PY data feed and persist them as separate reference tables in the operational database (Supabase/Postgres), not intermixed with event/claim tables.
+- **FR-028**: System MUST maintain these reference tables with a defined cadence: daily in-season, weekly off-season, and support on-demand manual refresh for breaking changes.
+- **FR-029**: System MUST provide stable identifiers and disambiguation: team_id (slug), player_id, names/aliases, position, and player_team_history, enabling reliable entity linking from headlines.
+
+- **FR-030**: Supabase (Postgres) MUST be the authoritative operational database for Events, Claims, evidence links, Entities, and reference lexicons; no alternative primary datastore may be used for this feature.
+- **FR-031**: All data access and integrations for this feature MUST use the project’s provided Python packages/libraries (approved internal packages) for Supabase and data handling to ensure consistency and observability.
+
+#### Confidence Computation and Status Thresholds (normative)
+
+Definitions
+- Unique source: a distinct publishing domain or official team/NFL property. Multiple articles from the same domain count once for corroboration.
+- Source tiers (policy-controlled):
+   - Tier A (Official): team sites, NFL.com, formal league statements → weight w=0.60
+   - Tier B (Major): nationally reputable outlets/beat reporters → weight w=0.35
+   - Tier C (Other): all others → weight w=0.20
+   - Use at most the top 4 unique sources by tier for scoring.
+- Consistency scope: values for key attributes within an Event (e.g., contract years/total, injury status). Contradictions are measured per attribute.
+
+Components (each in [0,1])
+- Evidence strength E: E = 1 − Π_i (1 − w_i), over the selected unique sources i. (Diminishing returns for additional sources.)
+- Corroboration Cb: Let u = number of unique sources (deduped by domain). Cb = min(1, (u − 1) / 3). (1 source→0.0; 2→0.33; 4+→1.0)
+- Consistency K: If any contradictions on key attributes exist, K = consistent_count / (consistent_count + contradictory_count); else K = 1. For Event-only items without claims, K = 1 unless explicit contradictions are detected across headlines.
+- Official boost O: O = 1 if any Tier A official source is present; else 0.
+- Rumor flag Rm: Rm = 1 if sources are labeled rumor-only or speculative; else 0.
+
+Score and clamping
+- Raw score: S_raw = 100 × (0.55·E + 0.25·Cb + 0.20·K) + 5·O − 10·Rm
+- Final score: S = clamp(S_raw, 0, 100)
+
+Status mapping (with hysteresis)
+- Rumor: S < 40 OR (no Tier A/B sources AND unique_source_count < 2)
+- Reported (promotion): S ≥ 65 OR (unique_source_count ≥ 2 AND K ≥ 0.60 and no explicit contradictions)
+- Confirmed (promotion): S ≥ 85 AND (Tier A present OR (unique_source_count ≥ 3 AND includes ≥1 Tier B))
+- Demotion: From Confirmed→Reported if S < 75 or an official retraction occurs. From Reported→Rumor if S < 55 or K < 0.40 due to contradictions.
+
+Additional rules
+- Per-domain cap: multiple articles from the same domain do not increase u and contribute only once to E (the highest-tier instance).
+- Supersession: when a later correction changes a key attribute, mark prior claim as superseded; recompute K and S immediately.
+- Unknowns: absence of claim values does not reduce K; only contradictions do. Unknowns must be stated as "unknown" in summaries.
+
+#### Reference Data Policy (normative)
+- Canonical sources: NFL_DATA_PY is the authoritative feed for Teams and Players.
+- Storage: keep Teams and Players in separate reference tables within Supabase/Postgres; do not duplicate into event/claim tables.
+- Minimum fields: teams(team_id/slug, names/aliases); players(player_id, name, aliases, position, optional player_team_history with date ranges).
+- Freshness: refresh on the stated cadence; provide an admin-triggered refresh. Late or missing items must not break ingestion; unknown entities remain unlinked until the next refresh.
+
+### Key Entities *(include if feature involves data)*
+- **Event**: A single real-world occurrence (e.g., signing, injury, game recap). Attributes: type, subtype, temporal context, first_seen/last_seen, confidence, status. Relationships: involves Teams/Players; relates to Games; has Claims; has Articles as evidence; may supersede/ be superseded by other Events.
+- **Team**: A canonical NFL team identity. Attributes: name/slug and aliases. Relationships: participates in Events; may be related to Players and Games.
+- **Player**: A canonical NFL player identity. Attributes: name, aliases, position. Relationships: participates in Events; may have current/prior team memberships.
+- **Game**: A specific NFL game instance. Attributes: season/week/phase and opponent context. Relationships: Events may relate to a Game (preview/recap/injury context).
+- **Claim**: A structured fact associated with an Event (e.g., contract terms, injury designation). Attributes: kind, values, confidence, status. Relationships: evidenced by Articles.
+- **Source**: A publisher/domain identity with a policy mode and tier. Relationships: publishes Articles.
+- **Article**: An ingested news item. Attributes: URL, title, publisher. Relationships: published by a Source; cited as evidence for Events and Claims.
+
+---
+
+## Review & Acceptance Checklist
+*GATE: Automated checks run during main() execution*
+
+### Content Quality
+- [ ] No implementation details (languages, frameworks, APIs)
+- [ ] Focused on user value and business needs
+- [ ] Written for non-technical stakeholders
+- [ ] All mandatory sections completed
+
+### Requirement Completeness
+- [ ] No [NEEDS CLARIFICATION] markers remain
+- [ ] Requirements are testable and unambiguous  
+- [ ] Success criteria are measurable
+- [ ] Scope is clearly bounded
+- [ ] Dependencies and assumptions identified
+
+---
+
+## Execution Status
+*Updated by main() during processing*
+
+- [ ] User description parsed
+- [ ] Key concepts extracted
+- [ ] Ambiguities marked
+- [ ] User scenarios defined
+- [ ] Requirements generated
+- [ ] Entities identified
+- [ ] Review checklist passed
+
+---

--- a/specs/002-vision-the-nfl/tasks.md
+++ b/specs/002-vision-the-nfl/tasks.md
@@ -1,0 +1,76 @@
+# Tasks: NFL Event Knowledge Graph
+
+**Input**: Design documents from `/specs/002-vision-the-nfl/`
+**Prerequisites**: plan.md (required), research.md, data-model.md, contracts/
+
+## Execution Flow (main)
+- This file is generated per template and tailored to the feature. Execute tasks top-to-bottom, honoring dependencies and [P] for safe parallelism.
+
+## Phase 3.1: Setup
+- [ ] T001 Ensure Supabase connection config is present and working (env, URL, key) in `src/database/supabase_client.py`
+- [ ] T002 [P] Add dependency lock/verify for `nfl_data_py` and ensure availability in runtime env (document in README if needed)
+- [ ] T003 [P] Add migration stubs for reference tables (teams, players, player_team_history) and KG tables (events, event_entities, claims, claim_sources, event_articles, sources) under `migrations/versions/`
+
+## Phase 3.2: Tests First (TDD) ⚠️ MUST COMPLETE BEFORE 3.3
+- [ ] T004 [P] Contract test GET /events in `tests/contract/test_events_list.py` (based on `contracts/openapi.yaml`)
+- [ ] T005 [P] Contract test GET /events/{event_id} in `tests/contract/test_event_details.py`
+- [ ] T006 [P] Contract test GET /events/{event_id}/summary in `tests/contract/test_event_summary.py`
+- [ ] T007 [P] Integration test: article→event happy path in `tests/integration/test_e2e_pipeline.py` asserting event created, entities linked, citation present, confidence computed
+- [ ] T008 [P] Integration test: dedup clustering within 5 days in `tests/integration/test_incremental_ingestion.py` asserting same event clustered and confidence increases with corroboration
+- [ ] T009 [P] Integration test: allowlisted claim extraction in `tests/integration/test_filtering_pipeline.py` asserting claim added with provenance and status
+
+## Phase 3.3: Core Implementation (ONLY after tests are failing)
+- [ ] T010 [P] Models: create reference tables mapping in `src/models` for teams, players, player_team_history (SQLAlchemy/Pydantic as used in repo)
+- [ ] T011 [P] Models: create KG tables mapping in `src/models` for events, event_entities, claims, claim_sources, event_articles, sources
+- [ ] T012 Service: reference loader using `nfl_data_py` to populate Supabase reference tables in `src/services/nfl_reference_loader.py` with cadence hooks
+- [ ] T013 Service: event signature and clustering (5-day window) in `src/services/simple_pipeline.py` or `src/services/pipeline.py` respecting idempotence
+- [ ] T014 Service: confidence computation per spec in `src/services/metrics.py` or a new `src/services/confidence.py`
+- [ ] T015 Service: claim extraction guardrailed by domain policy in `src/services/relevance_filter.py` or `src/services/rule_filter.py` with provenance recording
+- [ ] T016 Service: summary generator that cites after every fact in `src/services/log_aggregator.py` or a new `src/services/summary.py`
+- [ ] T017 API: implement GET /events endpoint in existing CLI/API surface (add a minimal http layer or CLI command) consistent with `contracts/openapi.yaml`
+- [ ] T018 API: implement GET /events/{event_id}`
+- [ ] T019 API: implement GET /events/{event_id}/summary`
+
+## Phase 3.4: Integration
+- [ ] T020 Wire ingestion to existing RSS/sitemap pipeline (`src/services/feed_ingester.py`, `src/services/rss_parser.py`, `src/services/sitemap_parser.py`) to call article→event path
+- [ ] T021 Ensure Supabase repositories exist or add them under `src/database/repositories/` for events, claims, links, and reference tables
+- [ ] T022 Logging/audit: log evidence additions, merges/splits, confidence recalculations in `src/services/log_aggregator.py`
+- [ ] T023 Observability counters: per-run metrics (events created/updated, claims added, merge/split, latency, LLM hit-rate) in `src/services/metrics.py`
+
+## Phase 3.5: Polish
+- [ ] T024 [P] Unit tests for confidence computation edge cases in `tests/unit/test_metrics.py`
+- [ ] T025 [P] Unit tests for signature hashing and idempotence in `tests/unit/test_async_utils.py` or new `tests/unit/test_signature.py`
+- [ ] T026 [P] Update docs `docs/api.md` to describe the new endpoints and examples
+- [ ] T027 [P] Update `specs/002-vision-the-nfl/quickstart.md` with concrete CLI/API calls
+- [ ] T028 Performance sanity: run on 1,000 articles; ensure median time-to-event < 20 min; document results in `tests/performance/test_performance_1000.py`
+
+## Dependencies
+- T004–T009 before T010–T019 (TDD)
+- T010 blocks T012, T021
+- T011 blocks T013–T015
+- T013 blocks T020
+- T014 blocks T023, summaries confidence display
+- T017–T019 depend on models/services
+
+## Parallel Execution Examples
+```
+# Contracts and integration tests in parallel
+Task: "Contract test GET /events in tests/contract/test_events_list.py"
+Task: "Contract test GET /events/{event_id} in tests/contract/test_event_details.py"
+Task: "Contract test GET /events/{event_id}/summary in tests/contract/test_event_summary.py"
+Task: "Integration test article→event in tests/integration/test_e2e_pipeline.py"
+Task: "Integration test clustering in tests/integration/test_incremental_ingestion.py"
+Task: "Integration test allowlisted claims in tests/integration/test_filtering_pipeline.py"
+
+# Model creation in parallel
+Task: "Models for reference tables in src/models"
+Task: "Models for KG tables in src/models"
+```
+
+## Validation Checklist
+- [ ] All contracts have corresponding tests (T004–T006)
+- [ ] All entities have model tasks (T010–T011)
+- [ ] All tests come before implementation
+- [ ] Parallel tasks touch different files only
+- [ ] Each task lists exact files or directories
+- [ ] Observability and audit trails included


### PR DESCRIPTION
This PR introduces the Spec-Driven Development artifacts for the NFL Event Knowledge Graph feature.

Includes:
- Specification (specs/002-vision-the-nfl/spec.md)
- Implementation Plan (specs/002-vision-the-nfl/plan.md)
- Phase 0 Research (specs/002-vision-the-nfl/research.md)
- Phase 1 Data Model (specs/002-vision-the-nfl/data-model.md)
- Contracts (OpenAPI) (specs/002-vision-the-nfl/contracts/)
- Quickstart guide (specs/002-vision-the-nfl/quickstart.md)
- Task list (specs/002-vision-the-nfl/tasks.md)

Key decisions:
- Supabase is the authoritative DB backend
- Reference data via nfl_data_py to dedicated tables
- 5-day event clustering window (signature-based)
- Confidence formula with hysteresis thresholds
- Connects to existing RSS/sitemap ingestion (no scraping)
- Use small LLMs only where it adds value

Next steps:
- Execute tasks.md (tests-first)
- Wire into existing ingestion and repositories
- Iterate on metrics and summaries

Constitution: Complies with no-scraping, transparency, cost, and structured-data principles.
